### PR TITLE
Remove offset calculation logic for switching between coordinate systems...

### DIFF
--- a/components/FreeDraw.js
+++ b/components/FreeDraw.js
@@ -1274,7 +1274,7 @@
                 originalEvent.preventDefault();
 
                 this.latLngs = [];
-                this.fromPoint = map.latLngToContainerPoint(event.latlng);
+                this.fromPoint = this.map.latLngToContainerPoint(event.latlng);
 
                 if (this.mode & L.FreeDraw.MODES.CREATE) {
 


### PR DESCRIPTION
....

I didn't realize a previous developer (pull request #25) fixed this bug, but I figured I would submit a pull request anyway.  My fix uses the built in transforms provided by the core leaflet library rather than maintaining a _getOffset method.
