### PR TITLE
[README] how to use the module inside a webpack builded project

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
   3. [Options](#options)
   4. [Classes](#classes)
   5. [Methods](#methods)
-  
+
 ![FreeDraw Screenshot](example/media/screenshot.png)
 
 ## Browser Support
@@ -48,6 +48,18 @@ const freeDraw = new FreeDraw();
 ```
 
 By attaching `FreeDraw` to your map layer, an SVG node will be appended to the DOM, and mouse event listeners will be attached to the `map` instance for creating and managing the geospatial polygons.
+
+**Note:** If you're using Webpack to run/build your project, don't forget to add those few lines to your config :
+
+```
+resolve: {
+  alias: {
+    L: 'leaflet',
+    ClipperLib: 'clipper-lib',
+    R: 'ramda',
+  },
+},
+```
 
 ### Markers
 


### PR DESCRIPTION
I sweat my shirt to import the module in my project. Everything works perfectly when I build the module in the example context after fork, but when I try to using with npm and `import` I have several errors. I try a lot of different ways to include the module until I finally realise that it was just a matter of aliases 😅 

This PR provides a quick way to inform users how to install and import the module, but a cleaner way can be to not “aliasing” external libraries (ex: d3 works fine)