### PR TITLE
Feature: Marker gets removed on Right Clicking it!

### DIFF
--- a/src/helpers/Edges.js
+++ b/src/helpers/Edges.js
@@ -1,5 +1,5 @@
 import { DivIcon, Marker, DomEvent } from 'leaflet';
-import { polygons, modesKey, notifyDeferredKey } from '../FreeDraw';
+import { polygons, modesKey, notifyDeferredKey, edgesKey } from '../FreeDraw';
 import { updateFor } from './Layer';
 import { CREATE, EDIT } from './Flags';
 import mergePolygons, { fillPolygon } from './Merge';
@@ -33,10 +33,18 @@ export default function createEdges(map, polygon, options) {
         const latLng = map.layerPointToLatLng(point);
         const marker = new Marker(latLng, { icon }).addTo(map);
 
+        marker.on('contextmenu', () => {
+            const newMarkers = markers.filter(m => (m !== marker));
+            const latlngs = newMarkers.map(m => [m.getLatLng().lat, m.getLatLng().lng]);
+            polygon.setLatLngs(latlngs);
+            polygon[edgesKey].map(edge => map.removeLayer(edge));
+            polygon[edgesKey] = createEdges(map, polygon, options);
+        });
+
         // Disable the propagation when you click on the marker.
         DomEvent.disableClickPropagation(marker);
 
-        marker.on('mousedown', function mouseDown() {
+        marker.on('mousedown', function mouseDown(e) {
 
             if (!(map[modesKey] & EDIT)) {
 
@@ -44,6 +52,10 @@ export default function createEdges(map, polygon, options) {
                 map.off('mousedown', mouseDown);
                 return;
 
+            }
+
+            if (e.originalEvent.which === 3) {
+                return;
             }
 
             // Disable the map dragging as otherwise it's difficult to reposition the edge.
@@ -84,6 +96,10 @@ export default function createEdges(map, polygon, options) {
                     // Re-enable the dragging of the map only if created mode is not enabled.
                     map.dragging.enable();
 
+                }
+
+                if (e.originalEvent.which === 3) {
+                    return;
                 }
 
                 // Stop listening to the events.


### PR DESCRIPTION
Hey!
So another feature i think we should add to FreeDraw is the ability to remove the Marker . 
Although `simplifyPolygon` of `Clipper` library removes unnecessary Markers, i often set the `simplifyFactor` to close to **0**. 
Hence finding the need to remove markers which i want :)

@Wildhoney tell me what do you think 😄 !