### PR TITLE
Mobile touch events to work on leaflet 1.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8104,9 +8104,9 @@
       }
     },
     "leaflet": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.6.0.tgz",
-      "integrity": "sha512-CPkhyqWUKZKFJ6K8umN5/D2wrJ2+/8UIpXppY7QDnUZW5bZL5+SEI2J7GBpwh4LIupOKqbNSQXgqmrEJopHVNQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.7.1.tgz",
+      "integrity": "sha512-/xwPEBidtg69Q3HlqPdU3DnrXQOvQU/CCHA1tcDQVzOwm91YMYaILjNp7L4Eaw5Z4sOYdbBz6koWyibppd8Zqw==",
       "dev": true
     },
     "levn": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "es6-weak-map": "^2.0.1",
     "express": "~4.16.3",
     "jsdom": "^9.8.3",
-    "leaflet": "~1.6.0",
+    "leaflet": "^1.7.1",
     "mocha": "~3.5.3",
     "nightmare": "~3.0.1",
     "ramda": "^0.22.1",

--- a/src/helpers/Map.js
+++ b/src/helpers/Map.js
@@ -1,0 +1,17 @@
+import { point } from 'leaflet';
+
+/**
+ * {@link https://github.com/Leaflet/Leaflet/issues/1542#issuecomment-151679021}
+ * @param {TouchEvent} event
+ * @param {HTMLElement} container
+ * @return {L.Point}
+ */
+export const touchEventToContainerPoint = (event, container) => {
+    const touch = event.touches[0];
+    const rect = container.getBoundingClientRect();
+
+    const lat = touch.clientX - rect.left - container.clientLeft;
+    const lng = touch.clientY - rect.top - container.clientTop;
+
+    return point(lat, lng);
+};

--- a/tests/FreeDraw.test.js
+++ b/tests/FreeDraw.test.js
@@ -1,7 +1,7 @@
 import test from 'ava';
 import { select } from 'd3-selection';
 import { LatLng, Point } from 'leaflet';
-import { spy } from 'sinon';
+import { spy, stub } from 'sinon';
 import FreeDraw, { polygons, edgesKey } from '../src/FreeDraw';
 import { updateFor } from '../src/helpers/Layer';
 import { NONE, CREATE, EDIT, DELETE, APPEND, EDIT_APPEND, ALL } from '../src/helpers/Flags';
@@ -30,10 +30,12 @@ const polygon = [new LatLng(51.50249181873096, -0.08634567260742189),
 test.beforeEach(t => {
 
     const node = t.context.node = document.createElement('div');
+    const mapContainer = document.createElement('div');
 
     t.context.map = {
         on: spy(),
         fire: spy(),
+        getContainer: stub().returns(mapContainer),
         dragging: {
             disable: spy(),
             enable: spy()
@@ -43,6 +45,7 @@ test.beforeEach(t => {
         layerPointToLatLng: spy(({ x, y }) => ({ lat: x, lng: y }))
     };
 
+    t.context.mapContainer = mapContainer;
     t.context.svg = select(node).append('svg');
     t.context.polygon = [...polygon];
     t.context.freeDraw = new FreeDraw({ mergePolygons: false, concavePolygon: false });
@@ -199,6 +202,19 @@ test('It should be able to set the mode on the map;', t => {
     t.truthy(node.classList.contains('mode-edit'));
     t.falsy(node.classList.contains('mode-delete'));
     t.falsy(node.classList.contains('mode-append'));
+
+});
+
+test('It should set map touch actions on and off when adding and removing the layer', async t => {
+
+    const { freeDraw, map, mapContainer } = t.context;
+    freeDraw.onAdd(map);
+
+    t.is(mapContainer.style.touchAction, 'none');
+
+    freeDraw.onRemove(map);
+
+    t.is(mapContainer.style.touchAction, '');
 
 });
 

--- a/tests/Map.test.js
+++ b/tests/Map.test.js
@@ -1,0 +1,17 @@
+import test from 'ava';
+import { stub } from 'sinon';
+import {touchEventToContainerPoint} from '../src/helpers/Map';
+
+
+test('It should calculate correct point', async (t) => {
+
+	const containerMock = {clientLeft: 10, clientTop: 20, getBoundingClientRect: stub()};
+	containerMock.getBoundingClientRect.returns({x: 10, y: 20, width: 100, height: 100, top: 20, right: 110, bottom: 961, left: 10});
+
+	const event = {touches: [{clientX: 25, clientY: 52, target: containerMock, identifier: 543543}]};
+
+	const point = touchEventToContainerPoint(event, containerMock);
+
+	t.is(point.x, 5);
+	t.is(point.y, 12);
+});

--- a/tests/functional/helpers/Polygons.js
+++ b/tests/functional/helpers/Polygons.js
@@ -2,19 +2,19 @@ export const createMergedPolygon = () => {
 
     const map = document.querySelector('section.map');
 
-    map.dispatchEvent(new MouseEvent('mousedown'));
-    map.dispatchEvent(new MouseEvent('mousemove', { clientX: 100, clientY: 100 }));
-    map.dispatchEvent(new MouseEvent('mousemove', { clientX: 100, clientY: 200 }));
-    map.dispatchEvent(new MouseEvent('mousemove', { clientX: 200, clientY: 200 }));
-    map.dispatchEvent(new MouseEvent('mousemove', { clientX: 200, clientY: 100 }));
-    map.dispatchEvent(new MouseEvent('mouseup'));
+    map.dispatchEvent(new MouseEvent('pointerdown'));
+    map.dispatchEvent(new MouseEvent('pointermove', { clientX: 100, clientY: 100 }));
+    map.dispatchEvent(new MouseEvent('pointermove', { clientX: 100, clientY: 200 }));
+    map.dispatchEvent(new MouseEvent('pointermove', { clientX: 200, clientY: 200 }));
+    map.dispatchEvent(new MouseEvent('pointermove', { clientX: 200, clientY: 100 }));
+    map.dispatchEvent(new MouseEvent('pointerup'));
 
-    map.dispatchEvent(new MouseEvent('mousedown'));
-    map.dispatchEvent(new MouseEvent('mousemove', { clientX: 150, clientY: 150 }));
-    map.dispatchEvent(new MouseEvent('mousemove', { clientX: 150, clientY: 250 }));
-    map.dispatchEvent(new MouseEvent('mousemove', { clientX: 250, clientY: 250 }));
-    map.dispatchEvent(new MouseEvent('mousemove', { clientX: 250, clientY: 150 }));
-    map.dispatchEvent(new MouseEvent('mouseup'));
+    map.dispatchEvent(new MouseEvent('pointerdown'));
+    map.dispatchEvent(new MouseEvent('pointermove', { clientX: 150, clientY: 150 }));
+    map.dispatchEvent(new MouseEvent('pointermove', { clientX: 150, clientY: 250 }));
+    map.dispatchEvent(new MouseEvent('pointermove', { clientX: 250, clientY: 250 }));
+    map.dispatchEvent(new MouseEvent('pointermove', { clientX: 250, clientY: 150 }));
+    map.dispatchEvent(new MouseEvent('pointerup'));
 
     return Array.from(document.querySelectorAll('path.leaflet-polygon'));
 
@@ -24,12 +24,12 @@ export const createFirstPolygon = () => {
 
     const map = document.querySelector('section.map');
 
-    map.dispatchEvent(new MouseEvent('mousedown'));
-    map.dispatchEvent(new MouseEvent('mousemove', { clientX: 50, clientY: 50 }));
-    map.dispatchEvent(new MouseEvent('mousemove', { clientX: 50, clientY: 100 }));
-    map.dispatchEvent(new MouseEvent('mousemove', { clientX: 100, clientY: 100 }));
-    map.dispatchEvent(new MouseEvent('mousemove', { clientX: 100, clientY: 50 }));
-    map.dispatchEvent(new MouseEvent('mouseup'));
+    map.dispatchEvent(new MouseEvent('pointerdown'));
+    map.dispatchEvent(new MouseEvent('pointermove', { clientX: 50, clientY: 50 }));
+    map.dispatchEvent(new MouseEvent('pointermove', { clientX: 50, clientY: 100 }));
+    map.dispatchEvent(new MouseEvent('pointermove', { clientX: 100, clientY: 100 }));
+    map.dispatchEvent(new MouseEvent('pointermove', { clientX: 100, clientY: 50 }));
+    map.dispatchEvent(new MouseEvent('pointerup'));
 
     return Array.from(document.querySelectorAll('path.leaflet-polygon'));
 
@@ -39,12 +39,12 @@ export const createSecondPolygon = () => {
 
     const map = document.querySelector('section.map');
 
-    map.dispatchEvent(new MouseEvent('mousedown'));
-    map.dispatchEvent(new MouseEvent('mousemove', { clientX: 150, clientY: 150 }));
-    map.dispatchEvent(new MouseEvent('mousemove', { clientX: 150, clientY: 250 }));
-    map.dispatchEvent(new MouseEvent('mousemove', { clientX: 250, clientY: 250 }));
-    map.dispatchEvent(new MouseEvent('mousemove', { clientX: 250, clientY: 150 }));
-    map.dispatchEvent(new MouseEvent('mouseup'));
+    map.dispatchEvent(new MouseEvent('pointerdown'));
+    map.dispatchEvent(new MouseEvent('pointermove', { clientX: 150, clientY: 150 }));
+    map.dispatchEvent(new MouseEvent('pointermove', { clientX: 150, clientY: 250 }));
+    map.dispatchEvent(new MouseEvent('pointermove', { clientX: 250, clientY: 250 }));
+    map.dispatchEvent(new MouseEvent('pointermove', { clientX: 250, clientY: 150 }));
+    map.dispatchEvent(new MouseEvent('pointerup'));
 
     return Array.from(document.querySelectorAll('path.leaflet-polygon'));
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4750,10 +4750,10 @@ lcid@^2.0.0:
   dependencies:
     invert-kv "^2.0.0"
 
-leaflet@~1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.6.0.tgz#aecbb044b949ec29469eeb31c77a88e2f448f308"
-  integrity sha512-CPkhyqWUKZKFJ6K8umN5/D2wrJ2+/8UIpXppY7QDnUZW5bZL5+SEI2J7GBpwh4LIupOKqbNSQXgqmrEJopHVNQ==
+leaflet@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.7.1.tgz#10d684916edfe1bf41d688a3b97127c0322a2a19"
+  integrity sha512-/xwPEBidtg69Q3HlqPdU3DnrXQOvQU/CCHA1tcDQVzOwm91YMYaILjNp7L4Eaw5Z4sOYdbBz6koWyibppd8Zqw==
 
 leven@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
# Description

Fixes problem with `map.on('touch')` events not working on leaflet >= 1.7 by changing the code to use L.DomEvent instead.

Fixes issues
- [x] https://github.com/Wildhoney/Leaflet.FreeDraw/issues/171
- [x] https://github.com/Wildhoney/Leaflet.FreeDraw/issues/161
- [x] https://github.com/Wildhoney/Leaflet.FreeDraw/issues/155
- [x] https://github.com/Wildhoney/Leaflet.FreeDraw/issues/3

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested drawing on leaflet 1.7.1 and leaflet 1.5.1

## Desktop (default and mobile touch simulation) 
- [x] Chrome 99.0. 
- [x] Firefox 98.0

## Mobile
- [x] Android 12 Firefox 99.1 and Chrome 100.0
- [x] iOS 15.0 Safari

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules